### PR TITLE
상담 삭제 기능 구현 

### DIFF
--- a/src/main/java/dev/be/loansystem/controller/CounselController.java
+++ b/src/main/java/dev/be/loansystem/controller/CounselController.java
@@ -9,7 +9,7 @@ import org.springframework.web.bind.annotation.*;
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/counsels")
-public class CounselController extends AbstractController{
+public class CounselController extends AbstractController {
 
     private final CounselService counselService;
 
@@ -26,5 +26,12 @@ public class CounselController extends AbstractController{
     @PutMapping("/{counselId}")
     public ResponseDTO<Response> update(@PathVariable Long counselId, @RequestBody Request request) {
         return ok(counselService.update(counselId, request));
+    }
+
+    @DeleteMapping("/{counselId}")
+    public ResponseDTO<Response> delete(@PathVariable Long counselId) {
+        counselService.delete(counselId);
+
+        return ok();
     }
 }

--- a/src/main/java/dev/be/loansystem/service/CounselService.java
+++ b/src/main/java/dev/be/loansystem/service/CounselService.java
@@ -9,4 +9,6 @@ public interface CounselService {
     Response get(Long counselId);
 
     Response update(Long counselId, Request request);
+
+    void delete(Long counselId);
 }

--- a/src/main/java/dev/be/loansystem/service/CounselServiceImpl.java
+++ b/src/main/java/dev/be/loansystem/service/CounselServiceImpl.java
@@ -57,4 +57,15 @@ public class CounselServiceImpl implements CounselService{
 
         return modelMapper.map(counsel, Response.class);
     }
+
+    @Override
+    public void delete(Long counselId) {
+        Counsel counsel = counselRepository.findById(counselId).orElseThrow(() -> {
+            throw new BaseException(ResultType.SYSTEM_ERROR);
+        });
+
+        counsel.setIsDeleted(true);
+
+        counselRepository.save(counsel);
+    }
 }

--- a/src/test/java/dev/be/loansystem/service/CounselServiceImplTest.java
+++ b/src/test/java/dev/be/loansystem/service/CounselServiceImplTest.java
@@ -104,4 +104,20 @@ class CounselServiceImplTest {
         assertThat(actual.getCounselId()).isSameAs(findId);
         assertThat(actual.getName()).isSameAs(request.getName());
     }
+
+    @Test
+    void Should_DeletedCounselEntity_When_RequestDeleteExistsCounselInfo() {
+        Long targetId = 1L;
+
+        Counsel entity = Counsel.builder()
+                .counselId(1L)
+                .build();
+
+        when(counselRepository.save(any(Counsel.class))).thenReturn(entity);
+        when(counselRepository.findById(targetId)).thenReturn(Optional.ofNullable(entity));
+
+        counselService.delete(targetId);
+
+        assertThat(entity.getIsDeleted()).isSameAs(true);
+    }
 }


### PR DESCRIPTION
- 상담 삭제 기능 구현
- `Counsel` 의 `is_deleted` 를 true로 변경하는 로직으로 구현
- `Counsel` 의 데이터 접근 조건이 `is_deleted` 가 false 이기 때문에 비즈니스 로직 상 삭제로 처리

This closes #9 